### PR TITLE
fix: protect stable functions from stub generator overwrite

### DIFF
--- a/dev/generate_stubs.R
+++ b/dev/generate_stubs.R
@@ -220,7 +220,7 @@ generate_ct_stubs <- function() {
   spec_with_text <- render_endpoint_stubs(endpoints_to_build, config = ct_config)
 
   # Write files
-  scaffold_result <- scaffold_files(spec_with_text, base_dir = "R", overwrite = TRUE, append = TRUE, quiet = TRUE)
+  scaffold_result <- scaffold_files(spec_with_text, base_dir = "R", overwrite = FALSE, append = TRUE, quiet = TRUE)
 
   scaffold_result
 }
@@ -342,7 +342,7 @@ generate_chemi_stubs <- function() {
     summarise(text = paste(text, collapse = "\n\n"), .groups = "drop")
 
   # Write files
-  scaffold_result <- scaffold_files(chemi_spec_aggregated, base_dir = "R", overwrite = TRUE, append = TRUE, quiet = TRUE)
+  scaffold_result <- scaffold_files(chemi_spec_aggregated, base_dir = "R", overwrite = FALSE, append = TRUE, quiet = TRUE)
 
   scaffold_result
 }
@@ -414,7 +414,7 @@ generate_cc_stubs <- function() {
   spec_with_text <- render_endpoint_stubs(endpoints_to_build, config = cc_config)
 
   # Write files
-  scaffold_result <- scaffold_files(spec_with_text, base_dir = "R", overwrite = TRUE, append = TRUE, quiet = TRUE)
+  scaffold_result <- scaffold_files(spec_with_text, base_dir = "R", overwrite = FALSE, append = TRUE, quiet = TRUE)
 
   scaffold_result
 }
@@ -461,9 +461,14 @@ if (nrow(all_results) == 0) {
   skipped <- sum(str_detect(all_results$action, "skipped"), na.rm = TRUE)
   errors <- sum(all_results$action == "error", na.rm = TRUE)
 
+  protected <- sum(all_results$action == "skipped_lifecycle", na.rm = TRUE)
+
   cli_alert_info("Created: {created} file(s)")
   cli_alert_info("Appended: {appended} file(s)")
   cli_alert_info("Skipped: {skipped} file(s)")
+  if (protected > 0) {
+    cli_alert_warning("Protected (lifecycle guard): {protected} file(s)")
+  }
   if (errors > 0) {
     cli_alert_danger("Errors: {errors} file(s)")
   }


### PR DESCRIPTION
Closes #95

## Summary
- **Lifecycle guard in `scaffold_files()`**: Before writing to an existing file, scans for `lifecycle::badge()` calls. If any badge is `stable`, `maturing`, `superseded`, `deprecated`, or `defunct`, the write is skipped with a warning. This prevents experimental stubs from destroying mature documentation.
- **Fallback matching in `find_endpoint_usages_base()`**: When endpoint string matching fails, checks if the expected file already exists and contains a real function definition. This reduces false negatives when stable functions use a different endpoint string format than what the schema generates.
- **Changed `overwrite=TRUE` to `overwrite=FALSE`** in all three `generate_*_stubs()` callers. Existing files are no longer overwritten; `append=TRUE` still allows adding new endpoints to multi-function files.

## Test plan
- [ ] Run `Rscript dev/generate_stubs.R` — verify `cc_detail.R` and `cc_export.R` (stable lifecycle) are reported as `skipped_lifecycle`
- [ ] Temporarily rename a stable function's endpoint string to a non-matching value, run generator, confirm it's still detected via the fallback function-definition check
- [ ] Verify new experimental stubs are still created for genuinely missing endpoints