### PR TITLE
fix(schema): preserve EPI Suite numeric precision

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -108,7 +108,10 @@ jobs:
           schema_files <- list.files("schema", pattern = "\\.json$", full.names = TRUE)
           for (f in schema_files) {
             json <- jsonlite::fromJSON(f, simplifyVector = FALSE)
-            jsonlite::write_json(sort_keys(json), f, pretty = TRUE, auto_unbox = TRUE)
+            # Keep the exact EPI example values. The default four digits can
+            # round a valid upstream change back to the committed value.
+            digits <- if (startsWith(basename(f), "epi-")) NA else 4
+            jsonlite::write_json(sort_keys(json), f, pretty = TRUE, auto_unbox = TRUE, digits = digits)
           }
           cli::cli_alert_info("Pretty-printed {length(schema_files)} schema files")
         shell: Rscript {0}


### PR DESCRIPTION
﻿## Summary

- preserve full numeric precision when the workflow formats EPI Suite schemas
- keep the existing four-digit formatting for CT and Cheminformatics schemas
- allow the known `0.0056` to `0.00555` example change to reach the automated schema PR

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/schema-check.yml`
- local live comparison produces only the expected `userHenrysLawConstant` example change

## Rollout finding

Schema workflow run 31419041771 downloaded the EPI document successfully, but the formatter rounded `0.00555` back to `0.0056`. This change fixes that end-to-end precision loss.
